### PR TITLE
Added uroot as a dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,15 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Depends: forecast
-Imports: glmnet, neuralnet, plotrix, MASS, tsutils
-Suggests: thief
+Imports: 
+    glmnet,
+    neuralnet,
+    plotrix,
+    MASS,
+    tsutils,
+    uroot
+Suggests: 
+    thief
 URL: http://kourentzes.com/forecasting/2017/02/10/forecasting-time-series-with-neural-networks-in-r/
 BugReports: https://github.com/trnnick/nnfor/issues
 RoxygenNote: 6.1.1


### PR DESCRIPTION
cc: @robjhyndman

The upcoming version of forecast no longer requires uroot to be installed (it is now a suggest). As the model functions in this package use forecast::nsdiffs, the uroot package must be installed upon package installation.

Please prepare a CRAN release to allow forecast v8.5 to be submitted.